### PR TITLE
all: synced with upstream

### DIFF
--- a/src/list.json
+++ b/src/list.json
@@ -111193,20 +111193,6 @@
   },
   {
     "web_pages": [
-      "http://www.kuas.edu.tw/"
-    ],
-    "name": "National Kaohsiung University of Applied Sciences",
-    "alpha_two_code": "TW",
-    "state-province": null,
-    "domains": [
-      "kuas.edu.tw"
-    ],
-    "country": "Taiwan, Province of China",
-    "id": 7924,
-    "abbr": "kuas"
-  },
-  {
-    "web_pages": [
       "http://www.lhu.edu.tw/"
     ],
     "name": "LungHwa University of Science and Technology",
@@ -111473,17 +111459,17 @@
   },
   {
     "web_pages": [
-      "http://www.nkfu.edu.tw/"
+      "https://www.nkust.edu.tw/"
     ],
-    "name": "National Kaohsiung First University of Science and Technology",
+    "name": "National Kaohsiung University of Science and Technology",
     "alpha_two_code": "TW",
     "state-province": null,
     "domains": [
-      "nkfu.edu.tw"
+      "nkust.edu.tw"
     ],
     "country": "Taiwan, Province of China",
     "id": 7944,
-    "abbr": "nkfu"
+    "abbr": "nkust"
   },
   {
     "web_pages": [


### PR DESCRIPTION
As the PR from upstream repository, https://github.com/Hipo/university-domains-list/pull/599

- Removed kuas.edu.tw - National Kaohsiung University of Applied Sciences
- Removed nkfust.efu.tw - National Kaohsiung First University of Science and Technology
- Added nkust.edu.tw - National Kaohsiung University of Science and Technology