### PR TITLE
modify: update nptu with new name.

### DIFF
--- a/src/list.json
+++ b/src/list.json
@@ -111511,7 +111511,7 @@
     ],
     "country": "Taiwan",
     "id": 7947,
-    "abbr": "nptu"
+    "abbr": "NPTU"
   },
   {
     "web_pages": [

--- a/src/list.json
+++ b/src/list.json
@@ -111501,17 +111501,17 @@
   },
   {
     "web_pages": [
-      "http://www.npttc.edu.tw/"
+      "https://www.nptu.edu.tw/"
     ],
-    "name": "National Pingtung Teachers College",
+    "name": "National Pingtung University",
     "alpha_two_code": "TW",
     "state-province": null,
     "domains": [
-      "npttc.edu.tw"
+      "nptu.edu.tw"
     ],
-    "country": "Taiwan, Province of China",
+    "country": "Taiwan",
     "id": 7947,
-    "abbr": "npttc"
+    "abbr": "nptu"
   },
   {
     "web_pages": [


### PR DESCRIPTION
npttc is old name.（thank @rumamitw01 to find this problem!）

http://www.npttc.edu.tw/ -> can't access.

https://zh.wikipedia.org/zh-tw/%E5%9C%8B%E7%AB%8B%E5%B1%8F%E6%9D%B1%E5%A4%A7%E5%AD%B8
2014/08：NPTTC change name to NPTU.

so... update name :D