### PR TITLE
chore: update UPTU to AKTU

### DIFF
--- a/src/list.json
+++ b/src/list.json
@@ -59193,17 +59193,17 @@
   },
   {
     "web_pages": [
-      "http://www.uptu.ac.in/"
+      "https://aktu.ac.in/"
     ],
-    "name": "Uttar Pradesh Technical University",
+    "name": "Dr. A.P.J. Abdul Kalam Technical University",
     "alpha_two_code": "IN",
     "state-province": "Uttar Pradesh",
     "domains": [
-      "uptu.ac.in"
+      "aktu.ac.in"
     ],
     "country": "India",
     "id": 4216,
-    "abbr": "uptu"
+    "abbr": "AKTU"
   },
   {
     "web_pages": [


### PR DESCRIPTION
This PR updates UPTU to AKTU (IN) as UPTU is renamed to AKTU back in 2015.

Resolves #11.