### PR TITLE
fix: wust site & name update

### DIFF
--- a/src/list.json
+++ b/src/list.json
@@ -96847,19 +96847,17 @@
   },
   {
     "web_pages": [
-      "http://www.pwr.wroc.pl/",
       "https://pwr.edu.pl/"
     ],
-    "name": "Technical University of Wroclaw",
+    "name": "Wroclaw University of Science and Technology",
     "alpha_two_code": "PL",
     "state-province": null,
     "domains": [
-      "pwr.wroc.pl",
       "pwr.edu.pl"
     ],
     "country": "Poland",
     "id": 6902,
-    "abbr": "wroc"
+    "abbr": "WUST"
   },
   {
     "web_pages": [


### PR DESCRIPTION
This pull request updates the `src/list.json` file to reflect the current naming and domain conventions for Wroclaw University of Science and Technology.

Updates to university information:

* Changed the name from "Technical University of Wroclaw" to "Wroclaw University of Science and Technology."
* Updated the abbreviation from "wroc" to "WUST."
* Replaced the outdated domain and web page (`pwr.wroc.pl` and `http://www.pwr.wroc.pl/`) with the current domain and web page (`pwr.edu.pl` and `https://pwr.edu.pl/`).